### PR TITLE
Release mcpshim-tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,6 @@ graph TD
 | **Agent context budget** | Large MCP schemas in prompt   | Alias-based local command workflows |
 | **Operational history**  | Ad-hoc logging                | Built-in call history in SQLite     |
 
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=mcpshim/mcpshim&type=date&legend=top-left)](https://www.star-history.com/#mcpshim/mcpshim&type=date&legend=top-left)
-
 ---
 
 ## Architecture

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mcpshim/mcpshim
 
-go 1.24
+go 1.25.7
 
 require (
 	github.com/mark3labs/mcp-go v0.44.0


### PR DESCRIPTION
Automated release from monorepo.

Pushed from `incubator/mcpshim/tool` on branch `next` → `main`.