### PR TITLE
Release mcpshim-tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,13 @@ go install github.com/mcpshim/mcpshim/cmd/mcpshim@latest
 
 ```bash
 mkdir -p ~/.config/mcpshim
-cp configs/mcpshim.example.yaml ~/.config/mcpshim/config.yaml
+cat > ~/.config/mcpshim/config.yaml <<'YAML'
+servers:
+  - name: notion
+    alias: notion
+    transport: http
+    url: https://mcp.notion.com/mcp
+YAML
 ```
 
 ### 3. Start daemon and inspect
@@ -331,6 +337,10 @@ model of the socket, OAuth in containers, and the operational caveats.
 
 ---
 
-## See Also
+## Ecosystem
 
-**[Pantalk](https://github.com/pantalk/pantalk)** - Give your AI agent a voice on every chat platform. MCPShim gives your agent tools; Pantalk gives it a voice across Slack, Discord, Telegram, and more. Together they form a complete agent infrastructure stack.
+| Project                                       | Role                                                           |
+| --------------------------------------------- | -------------------------------------------------------------- |
+| [zot](https://github.com/openzot/openzot)     | Run complete coding tasks autonomously from a single brief     |
+| [Pantalk](https://github.com/pantalk/pantalk) | Connect coding agents to the chat platforms people already use |
+| [crmkit](https://github.com/crmkit/crmkit)    | Give agents a shared CRM and system of record over HTTP or MCP |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -437,8 +437,8 @@ is two hops from your Notion workspace. That composition is the point of the
 stack - and the reason to be deliberate about which servers are in the registry
 of the daemon that a chat-reachable agent can talk to.
 
-If you run [Pantalk Station](https://github.com/pantalk/station), the same logic
-holds: Station is explicitly a single-tenant trusted-host environment, so an
+If you run [Pantalk Ghost](https://github.com/pantalk/ghost), the same logic
+holds: Ghost is explicitly a single-tenant trusted-host environment, so an
 `mcpshimd` reachable from inside it inherits that posture. Keep its registry
 narrow.
 


### PR DESCRIPTION
Automated release from monorepo.

Pushed from `incubator/mcpshim/tool` on branch `next` → `main`.